### PR TITLE
Add ability to enumerate over a specific mount in the search path

### DIFF
--- a/src/physfs.c
+++ b/src/physfs.c
@@ -3138,6 +3138,11 @@ int PHYSFS_flush(PHYSFS_File *handle)
 
 int PHYSFS_stat(const char *_fname, PHYSFS_Stat *stat)
 {
+    return PHYSFS_statFromMountPoint(_fname, stat, 0);
+}
+
+int PHYSFS_statFromMountPoint(const char *_fname, PHYSFS_Stat *stat, const char *mountPoint)
+{
     int retval = 0;
     char *allocated_fname;
     char *fname;
@@ -3174,6 +3179,8 @@ int PHYSFS_stat(const char *_fname, PHYSFS_Stat *stat)
             int exists = 0;
             for (i = searchPath; ((i != NULL) && (!exists)); i = i->next)
             {
+                if (mountPoint && strcmp(i->dirName, mountPoint) != 0)
+                    continue;
                 char *arcfname = fname;
                 exists = partOfMountPoint(i, arcfname);
                 if (exists)
@@ -3188,6 +3195,8 @@ int PHYSFS_stat(const char *_fname, PHYSFS_Stat *stat)
                     if ((retval) || (currentErrorCode() != PHYSFS_ERR_NOT_FOUND))
                         exists = 1;
                 } /* else if */
+                if (mountPoint)
+                    break;
             } /* for */
         } /* else */
     } /* if */

--- a/src/physfs.c
+++ b/src/physfs.c
@@ -2538,6 +2538,11 @@ static PHYSFS_EnumerateCallbackResult enumCallbackFilterSymLinks(void *_data,
 
 int PHYSFS_enumerate(const char *_fn, PHYSFS_EnumerateCallback cb, void *data)
 {
+    return PHYSFS_enumerateFromMountPoint(_fn, cb, data, 0);
+}
+
+int PHYSFS_enumerateFromMountPoint(const char *_fn, PHYSFS_EnumerateCallback cb, void *data, const char *mountPoint)
+{
     PHYSFS_EnumerateCallbackResult retval = PHYSFS_ENUM_OK;
     size_t len;
     char *allocated_fname;
@@ -2568,6 +2573,9 @@ int PHYSFS_enumerate(const char *_fn, PHYSFS_EnumerateCallback cb, void *data)
 
         for (i = searchPath; (retval == PHYSFS_ENUM_OK) && i; i = i->next)
         {
+            if (mountPoint && strcmp(i->dirName, mountPoint) != 0)
+                continue;
+
             char *arcfname = fname;
 
             if (partOfMountPoint(i, arcfname))
@@ -2605,6 +2613,8 @@ int PHYSFS_enumerate(const char *_fn, PHYSFS_EnumerateCallback cb, void *data)
                                                  cb, _fn, data);
                 } /* else */
             } /* else if */
+            if (mountPoint)
+                break;
         } /* for */
 
     } /* if */

--- a/src/physfs.h
+++ b/src/physfs.h
@@ -2779,6 +2779,8 @@ typedef PHYSFS_EnumerateCallbackResult (*PHYSFS_EnumerateCallback)(void *data,
  */
 PHYSFS_DECL int PHYSFS_enumerate(const char *dir, PHYSFS_EnumerateCallback c,
                                  void *d);
+PHYSFS_DECL int PHYSFS_enumerateFromMountPoint(const char *dir, PHYSFS_EnumerateCallback c,
+                                 void *d, const char *mountPoint);
 
 
 /**

--- a/src/physfs.h
+++ b/src/physfs.h
@@ -2911,6 +2911,7 @@ typedef struct PHYSFS_Stat
  * \sa PHYSFS_Stat
  */
 PHYSFS_DECL int PHYSFS_stat(const char *fname, PHYSFS_Stat *stat);
+PHYSFS_DECL int PHYSFS_statFromMountPoint(const char *fname, PHYSFS_Stat *stat, const char *mountPoint);
 
 
 /**

--- a/src/physfs_archiver_7z.c
+++ b/src/physfs_archiver_7z.c
@@ -286,7 +286,8 @@ static PHYSFS_Io *SZIP_openRead(void *opaque, const char *path)
                         &blockIndex, &outBuffer, &outBufferSize, &offset,
                         &outSizeProcessed, alloc, alloc);
     GOTO_IF(rc != SZ_OK, szipErrorCode(rc), SZIP_openRead_failed);
-    GOTO_IF(outBuffer == NULL, PHYSFS_ERR_OUT_OF_MEMORY, SZIP_openRead_failed);
+    GOTO_IF((outBuffer == NULL) && (SzArEx_GetFileSize(&info->db, entry->dbidx) != 0),
+            PHYSFS_ERR_OUT_OF_MEMORY, SZIP_openRead_failed);
 
     io->destroy(io);
     io = NULL;

--- a/src/physfs_archiver_7z.c
+++ b/src/physfs_archiver_7z.c
@@ -185,9 +185,10 @@ static int szipLoadEntries(SZIPinfo *info)
 {
     int retval = 0;
 
-    if (__PHYSFS_DirTreeInit(&info->tree, sizeof (SZIPentry), 1, 0))
+    const PHYSFS_uint32 count = info->db.NumFiles;
+
+    if (__PHYSFS_DirTreeInitWithEntryCount(&info->tree, sizeof (SZIPentry), 1, 0, count))
     {
-        const PHYSFS_uint32 count = info->db.NumFiles;
         PHYSFS_uint32 i;
         for (i = 0; i < count; i++)
             BAIL_IF_ERRPASS(!szipLoadEntry(info, i), 0);

--- a/src/physfs_archiver_grp.c
+++ b/src/physfs_archiver_grp.c
@@ -76,7 +76,7 @@ static void *GRP_openArchive(PHYSFS_Io *io, const char *name,
     BAIL_IF_ERRPASS(!__PHYSFS_readAll(io, &count, sizeof(count)), NULL);
     count = PHYSFS_swapULE32(count);
 
-    unpkarc = UNPK_openArchive(io, 0, 1);
+    unpkarc = UNPK_openArchiveWithEntryCount(io, 0, 1, count);
     BAIL_IF_ERRPASS(!unpkarc, NULL);
 
     if (!grpLoadEntries(io, count, unpkarc))

--- a/src/physfs_archiver_mvl.c
+++ b/src/physfs_archiver_mvl.c
@@ -70,7 +70,7 @@ static void *MVL_openArchive(PHYSFS_Io *io, const char *name,
     BAIL_IF_ERRPASS(!__PHYSFS_readAll(io, &count, sizeof(count)), NULL);
     count = PHYSFS_swapULE32(count);
 
-    unpkarc = UNPK_openArchive(io, 0, 1);
+    unpkarc = UNPK_openArchiveWithEntryCount(io, 0, 1, count);
     BAIL_IF_ERRPASS(!unpkarc, NULL);
 
     if (!mvlLoadEntries(io, count, unpkarc))

--- a/src/physfs_archiver_qpak.c
+++ b/src/physfs_archiver_qpak.c
@@ -87,7 +87,7 @@ static void *QPAK_openArchive(PHYSFS_Io *io, const char *name,
     BAIL_IF_ERRPASS(!io->seek(io, pos), NULL);
 
     /* !!! FIXME: check case_sensitive and only_usascii params for this archive. */
-    unpkarc = UNPK_openArchive(io, 1, 0);
+    unpkarc = UNPK_openArchiveWithEntryCount(io, 1, 0, count);
     BAIL_IF_ERRPASS(!unpkarc, NULL);
 
     if (!qpakLoadEntries(io, count, unpkarc))

--- a/src/physfs_archiver_slb.c
+++ b/src/physfs_archiver_slb.c
@@ -95,7 +95,7 @@ static void *SLB_openArchive(PHYSFS_Io *io, const char *name,
     BAIL_IF_ERRPASS(!io->seek(io, tocPos), NULL);
 
     /* !!! FIXME: check case_sensitive and only_usascii params for this archive. */
-    unpkarc = UNPK_openArchive(io, 1, 0);
+    unpkarc = UNPK_openArchiveWithEntryCount(io, 1, 0, count);
     BAIL_IF_ERRPASS(!unpkarc, NULL);
 
     if (!slbLoadEntries(io, count, unpkarc))

--- a/src/physfs_archiver_unpacked.c
+++ b/src/physfs_archiver_unpacked.c
@@ -287,10 +287,14 @@ void *UNPK_addEntry(void *opaque, char *name, const int isdir,
 
 void *UNPK_openArchive(PHYSFS_Io *io, const int case_sensitive, const int only_usascii)
 {
+    return UNPK_openArchiveWithEntryCount(io, case_sensitive, only_usascii, 0);
+}
+void *UNPK_openArchiveWithEntryCount(PHYSFS_Io *io, const int case_sensitive, const int only_usascii, const PHYSFS_uint32 entry_count)
+{
     UNPKinfo *info = (UNPKinfo *) allocator.Malloc(sizeof (UNPKinfo));
     BAIL_IF(!info, PHYSFS_ERR_OUT_OF_MEMORY, NULL);
 
-    if (!__PHYSFS_DirTreeInit(&info->tree, sizeof (UNPKentry), case_sensitive, only_usascii))
+    if (!__PHYSFS_DirTreeInitWithEntryCount(&info->tree, sizeof (UNPKentry), case_sensitive, only_usascii, entry_count))
     {
         allocator.Free(info);
         return NULL;

--- a/src/physfs_archiver_vdf.c
+++ b/src/physfs_archiver_vdf.c
@@ -130,7 +130,7 @@ static void *VDF_openArchive(PHYSFS_Io *io, const char *name,
     BAIL_IF_ERRPASS(!io->seek(io, rootCatOffset), NULL);
 
     /* !!! FIXME: check case_sensitive and only_usascii params for this archive. */
-    unpkarc = UNPK_openArchive(io, 1, 0);
+    unpkarc = UNPK_openArchiveWithEntryCount(io, 1, 0, count);
     BAIL_IF_ERRPASS(!unpkarc, NULL);
 
     if (!vdfLoadEntries(io, count, vdfDosTimeToEpoch(timestamp), unpkarc))

--- a/src/physfs_archiver_wad.c
+++ b/src/physfs_archiver_wad.c
@@ -95,7 +95,7 @@ static void *WAD_openArchive(PHYSFS_Io *io, const char *name,
 
     BAIL_IF_ERRPASS(!io->seek(io, directoryOffset), 0);
 
-    unpkarc = UNPK_openArchive(io, 0, 1);
+    unpkarc = UNPK_openArchiveWithEntryCount(io, 0, 1, count);
     BAIL_IF_ERRPASS(!unpkarc, NULL);
 
     if (!wadLoadEntries(io, count, unpkarc))

--- a/src/physfs_archiver_zip.c
+++ b/src/physfs_archiver_zip.c
@@ -1661,7 +1661,7 @@ static int ZIP_stat(void *opaque, const char *filename, PHYSFS_Stat *stat)
     if (entry == NULL)
         return 0;
 
-    else if (!zip_resolve(info->io, info, entry))
+    else if (entry->resolved != ZIP_UNRESOLVED_FILE && !zip_resolve(info->io, info, entry))
         return 0;
 
     else if (entry->resolved == ZIP_DIRECTORY)

--- a/src/physfs_archiver_zip.c
+++ b/src/physfs_archiver_zip.c
@@ -1490,7 +1490,7 @@ static void *ZIP_openArchive(PHYSFS_Io *io, const char *name,
 
     if (!zip_parse_end_of_central_dir(info, &dstart, &cdir_ofs, &count))
         goto ZIP_openarchive_failed;
-    else if (!__PHYSFS_DirTreeInit(&info->tree, sizeof (ZIPentry), 1, 0))
+    else if (!__PHYSFS_DirTreeInitWithEntryCount(&info->tree, sizeof (ZIPentry), 1, 0, count))
         goto ZIP_openarchive_failed;
 
     root = (ZIPentry *) info->tree.root;

--- a/src/physfs_internal.h
+++ b/src/physfs_internal.h
@@ -388,6 +388,7 @@ int __PHYSFS_readAll(PHYSFS_Io *io, void *buf, const size_t len);
 
 /* LOTS of legacy formats that only use US ASCII, not actually UTF-8, so let them optimize here. */
 void *UNPK_openArchive(PHYSFS_Io *io, const int case_sensitive, const int only_usascii);
+void *UNPK_openArchiveWithEntryCount(PHYSFS_Io *io, const int case_sensitive, const int only_usascii, const PHYSFS_uint32 entry_count);
 void UNPK_abandonArchive(void *opaque);
 void UNPK_closeArchive(void *opaque);
 void *UNPK_addEntry(void *opaque, char *name, const int isdir,
@@ -428,6 +429,7 @@ typedef struct __PHYSFS_DirTree
 
 /* LOTS of legacy formats that only use US ASCII, not actually UTF-8, so let them optimize here. */
 int __PHYSFS_DirTreeInit(__PHYSFS_DirTree *dt, const size_t entrylen, const int case_sensitive, const int only_usascii);
+int __PHYSFS_DirTreeInitWithEntryCount(__PHYSFS_DirTree *dt, const size_t entrylen, const int case_sensitive, const int only_usascii, const PHYSFS_uint64 entry_count);
 void *__PHYSFS_DirTreeAdd(__PHYSFS_DirTree *dt, char *name, const int isdir);
 void *__PHYSFS_DirTreeFind(__PHYSFS_DirTree *dt, const char *path);
 PHYSFS_EnumerateCallbackResult __PHYSFS_DirTreeEnumerate(void *opaque,


### PR DESCRIPTION
This turned out to be simple to add, fortunately. This will help with building the path cache in mkxp-z.